### PR TITLE
Made symlinks maintain relative folder structure

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,9 @@ module.exports = function() {
         if (typeof out === 'undefined') {
             cb(new Error('gulp-symlink: A destination folder is required.'));
         }
-        var dest = process.cwd() + path.sep + out;
+        var dest = process.cwd() + path.sep + out + path.sep + path.dirname(path.relative(file.base, file.path));
         var sym = path.resolve(file.path, dest) + path.sep + path.basename(file.path);
+
         try {
             fs.symlinkSync(file.path, sym);
             // That was easy!


### PR DESCRIPTION
For example,

``` js
gulp.src('lib/**/images/*')
.pipe(symlink('./build'))
```

With project structure

```
lib/
  pages/
     cool-page/
         images/a.png
lib/
  components/
     cool-component/
         images/b.png
```

Would result in:

```
build/
   cool-page/
       images/a.png
   cool-component/
       images/b.png
```

This is more consistent with `gulp.dest`'s behavior.
