### PR TITLE
Fixes full paths issue.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,14 +7,13 @@ var map  = require('map-stream'),
     mkdirp = require('mkdirp').sync,
     fs   = require('fs');
 
-module.exports = function() {
-    var out = arguments[0];
+module.exports = function(out) {
     return map(function(file, cb) {
         if (typeof out === 'undefined') {
             cb(new Error('gulp-symlink: A destination folder is required.'));
         }
-        var dest = process.cwd() + path.sep + out + path.sep + path.dirname(path.relative(file.base, file.path));
-        var sym = path.resolve(file.path, dest) + path.sep + path.basename(file.path);
+        var dest = path.resolve(file.base, out);
+        var sym = path.join(path.resolve(file.path, dest), path.basename(file.path));
 
         try {
             fs.symlinkSync(file.path, sym);

--- a/test.js
+++ b/test.js
@@ -10,54 +10,63 @@ var expect = require('chai').expect,
     path = require('path'),
     fs = require('fs');
 
-var testDir = 'test';
-var testFile = 'index.js';
-var testPath = testDir + path.sep + testFile;
-var subDir = 'subdir';
-var subTestPath = testDir + path.sep + subDir + path.sep + testFile;
-
 describe('gulp-symlink', function() {
-    it('should throw if no directory was specified', function(cb) {
-        var stream = symlink();
-        try {
+    function test(testDir) {
+        var testFile = 'index.js';
+        var testPath = path.join(testDir, testFile);
+        var subDir = 'subdir';
+        var subTestPath = path.join(testDir, subDir, testFile);
+
+        it('should throw if no directory was specified', function(cb) {
+            var stream = symlink();
+            try {
+                stream.write(new gutil.File({
+                    path: path.join(process.cwd(), testFile)
+                }));
+            } catch (e) {
+                expect(e.toString()).to.contain.string('A destination folder is required.');
+                cb();
+            }
+        });
+        it('should create symlinks', function(cb) {
+            var stream = symlink(testDir);
+
+            stream.on('data', function() {
+                expect(fs.existsSync(testPath)).to.be.true;
+                expect(fs.lstatSync(testPath).isSymbolicLink()).to.be.true;
+                cb();
+            });
+
             stream.write(new gutil.File({
-                path: process.cwd() + path.sep + testFile
+                path: path.join(process.cwd(), testFile)
             }));
-        } catch (e) {
-            expect(e.toString()).to.contain.string('A destination folder is required.');
-            cb();
-        }
-    });
-    it('should create symlinks', function(cb) {
-        var stream = symlink(testDir);
-
-        stream.on('data', function() {
-            expect(fs.existsSync(testPath)).to.be.true;
-            expect(fs.lstatSync(testPath).isSymbolicLink()).to.be.true;
-            cb();
         });
+        it('should create symlinks in nested directories', function(cb) {
+            var stream = symlink(path.join(testDir, subDir));
 
-        stream.write(new gutil.File({
-            path: process.cwd() + path.sep + testFile
-        }));
-    });
-    it('should create symlinks in nested directories', function(cb) {
-        var stream = symlink(testDir + path.sep + subDir);
+            stream.on('data', function() {
+                expect(fs.existsSync(subTestPath)).to.be.true;
+                expect(fs.lstatSync(subTestPath).isSymbolicLink()).to.be.true;
+                cb();
+            });
 
-        stream.on('data', function() {
-            expect(fs.existsSync(subTestPath)).to.be.true;
-            expect(fs.lstatSync(subTestPath).isSymbolicLink()).to.be.true;
-            cb();
+            stream.write(new gutil.File({
+                path: path.join(process.cwd(), testFile)
+            }));
         });
+        after(function() {
+            fs.unlinkSync(subTestPath);
+            fs.rmdirSync(path.join(testDir, subDir));
+            fs.unlinkSync(testPath);
+            fs.rmdirSync(testDir);
+        });
+    }
 
-        stream.write(new gutil.File({
-            path: process.cwd() + path.sep + testFile
-        }));
+    describe('using relative path', function() {
+        test('test');
     });
-    after(function() {
-        fs.unlinkSync(subTestPath);
-        fs.rmdirSync(testDir + path.sep + subDir);
-        fs.unlinkSync(testPath);
-        fs.rmdirSync(testDir);
+
+    describe('using full path', function() {
+        test(__dirname + '/test');
     });
 });


### PR DESCRIPTION
Currently it's impossible to pass full path into `symlink()`. This patch addresses that.
