### PR TITLE
Exporting the module's instance of File from gulp util

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,6 +171,7 @@ var absolutesymlinker = function(symlink, options) {
 module.exports           = relativesymlinker;
 module.exports.relative  = relativesymlinker;
 module.exports.absolute  = absolutesymlinker;
+module.exports.File      = File;
 
 module.exports._setDebug = function(value) {
   debug = value;


### PR DESCRIPTION
@ben-eb I think this change will fix that problem I was having. In my gulpfile where I was using symlink, I'm pretty sure that my instance of `gulp-util` wasn't the same as the one being used by this module, so that `instanceof` check would always return false. By exporting the modules instance of file, in my gulpfile I can replace `gutil.File` with `symlink.File` like here: 

```
gulp.src(paths.preCommit)
    .pipe(symlink(function () {
        return new symlink.File({
            cwd: process.cwd(),
            path: paths.gitHooks
        });
    }, {force: true}));
```

and then everything works great. Let me know what you think!
