### PR TITLE
Log symlink.path instead of destination on error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ var symlinker = function(destination, resolver, options) {
 
       //No force option, we can't override!
       if(exists && !options.force) {
-        return errored.call(self, 'Destination file exists ('+destination+') - use force option to replace', callback);
+        return errored.call(self, 'Destination file exists ('+symlink.path+') - use force option to replace', callback);
       } else {
 
         async.waterfall([


### PR DESCRIPTION
Currently `destination` is console.logged on error. When `destination` is a function this leads to confusing error messages, such as the following:

```
Destination file exists (function (file) {
	return path.join(config.dest, file.relative);
}) - use force option to replace
```
