### PR TITLE
Full path now given for windows juntions

### DIFF
--- a/index.js
+++ b/index.js
@@ -154,7 +154,7 @@ var symlinker = function(destination, resolver, options) {
                   // Try with type "junction" on Windows
                   // Junctions behave equally to true symlinks and can be created in
                   // non elevated terminal (well, not always..)
-                  fs.symlink(source.resolved, symlink.path, 'junction', function(err) {
+                  fs.symlink(source.path, symlink.path, 'junction', function(err) {
                     if (err) {
                       return errored.call(self, err, callback);
                     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-symlink",
-  "version": "2.1.3",
+  "version": "2.1.2",
   "description": "Create symlinks during your gulp build.",
   "license": "MIT",
   "homepage": "https://github.com/ben-eb/gulp-symlink",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-symlink",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Create symlinks during your gulp build.",
   "license": "MIT",
   "homepage": "https://github.com/ben-eb/gulp-symlink",


### PR DESCRIPTION
On windows, relative path for junction do not work.
This is a small fix to create junctions with full path rather than relative path.
